### PR TITLE
Update isotools_alzheimer.ipynb

### DIFF
--- a/docs/notebooks/isotools_alzheimer.ipynb
+++ b/docs/notebooks/isotools_alzheimer.ipynb
@@ -22,7 +22,7 @@
     "    \n",
     "    # download gencode reference annotation (46.2 MB)\n",
     "    gff='gencode.v36.chr_patch_hapl_scaff.annotation'\n",
-    "    annotation_link= ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_36/${gff}.gff3.gz\n",
+    "    annotation_link=ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_36/${gff}.gff3.gz\n",
     "    wget -P reference/ ${annotation_link} \n",
     "    \n",
     "    # sort by chromosome and position\n",

--- a/docs/notebooks/isotools_alzheimer.ipynb
+++ b/docs/notebooks/isotools_alzheimer.ipynb
@@ -26,7 +26,7 @@
     "    wget -P reference/ ${annotation_link} \n",
     "    \n",
     "    # sort by chromosome and position\n",
-    "    (zcat ${gff}.gff3.gz| grep ^\"#\" ; zcat reference/${gff}.gff3.gz|grep -v ^\"#\"| sort -k1,1 -k4,4n)|bgzip  > reference/${gff}_sorted.gff3.gz\n",
+    "    (zcat reference/${gff}.gff3.gz| grep ^\"#\" ; zcat reference/${gff}.gff3.gz|grep -v ^\"#\"| sort -k1,1 -k4,4n)|bgzip  > reference/${gff}_sorted.gff3.gz\n",
     "    # create index\n",
     "    tabix -p gff reference/${gff}_sorted.gff3.gz\n",
     "    \n",


### PR DESCRIPTION
fix: superfluous space in bash variable assignment

otherwise bash wont do variable assignment